### PR TITLE
update URLs to reflect repo transfer to wannier-developers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,11 @@
 site_name: Wannier90 I/O with Python
-site_url: https://jimustafa.github.io/wannier90io-python
+site_url: https://wannier-developers.github.io/wannier90io-python
 site_author: Jamal Mustafa
 site_description: >-
   Wannier90 I/O with Python
 
-repo_name: jimustafa/wannier90io-python
-repo_url: https://github.com/jimustafa/wannier90io-python
+repo_name: wannier-developers/wannier90io-python
+repo_url: https://github.com/wannier-developers/wannier90io-python
 edit_uri: ''
 
 theme:
@@ -40,7 +40,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/jimustafa
+      link: https://github.com/wannier-developers
 
 markdown_extensions:
   - pymdownx.snippets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
 dynamic=['version']
 
 [project.urls]
-Documentation = "https://github.com/jimustafa/wannier90io-python#readme"
-Issues = "https://github.com/jimustafa/wannier90io-python/issues"
-Source = "https://github.com/jimustafa/wannier90io-python"
+Documentation = "https://github.com/wannier-developers/wannier90io-python#readme"
+Issues = "https://github.com/wannier-developers/wannier90io-python/issues"
+Source = "https://github.com/wannier-developers/wannier90io-python"
 
 [tool.hatch.build]
 only-packages = true


### PR DESCRIPTION
Also need to change the link in the About section of the repo homepage. Looks like I do not have permission to change repo settings.